### PR TITLE
Fix mobile UI bug and add spoiler page

### DIFF
--- a/src/app/call-guide/page.tsx
+++ b/src/app/call-guide/page.tsx
@@ -2,6 +2,7 @@ export default function CallGuidePage() {
   return (
     <main className="container" style={{ textAlign: 'center', paddingTop: '4rem' }}>
       <h1 className="header-title">콜 가이드</h1>
+      <p className="header-subtitle">추가 예정입니다.</p>
     </main>
   );
 }

--- a/src/app/concert-guide/page.tsx
+++ b/src/app/concert-guide/page.tsx
@@ -2,6 +2,7 @@ export default function CallGuidePage() {
   return (
     <main className="container" style={{ textAlign: 'center', paddingTop: '4rem' }}>
       <h1 className="header-title">공연 가이드</h1>
+      <p className="header-subtitle">추가 예정입니다.</p>
     </main>
   );
 }

--- a/src/app/exhibition-info/page.tsx
+++ b/src/app/exhibition-info/page.tsx
@@ -2,6 +2,7 @@ export default function ExhibitionInfoPage() {
   return (
     <main className="container" style={{ textAlign: 'center', paddingTop: '4rem' }}>
       <h1 className="header-title">기획전 정보</h1>
+      <p className="header-subtitle">추가 예정입니다.</p>
     </main>
   );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -861,6 +861,7 @@ body {
     width: 60px;
     height: 60px;
     margin-bottom: 8px;
+    font-size: 0.75rem;
   }
 }
 
@@ -993,4 +994,11 @@ body {
   border-radius: 8px;
   font-size: 0.875rem;
   color: var(--text-secondary);
+  background: rgba(0, 0, 0, 0.4);
+}
+
+.block-placeholder {
+  padding: 8px 16px;
+  border-radius: 8px;
+  visibility: hidden;
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -46,6 +46,7 @@ body {
   max-width: 1200px;
   margin: 0 auto;
   padding: 0 24px;
+  position: relative;
 }
 
 /* Landing Page Styles */
@@ -638,13 +639,18 @@ body {
 
   .footer-nav-list {
     flex-direction: column;
-    align-items: center;
+    align-items: stretch;
     gap: 16px;
+    flex-wrap: nowrap;
+  }
+
+  .footer-nav-list li {
+    width: 100%;
   }
 
   .footer-nav-list a {
     width: 100%;
-    max-width: 300px;
+    max-width: none;
     text-align: center;
   }
 }
@@ -663,6 +669,19 @@ body {
   .landing-cta {
     padding: 14px 28px;
     font-size: 1rem;
+  }
+
+  .nav-bar {
+    font-size: 0.875rem;
+    gap: 12px;
+  }
+
+  .header-title {
+    font-size: 1.8rem;
+  }
+
+  .landing-title {
+    font-size: 1.8rem;
   }
 }
 
@@ -795,6 +814,7 @@ body {
   color: var(--text-primary);
   text-decoration: none;
   transition: color 0.3s ease;
+  white-space: nowrap;
 }
 
 .nav-link:hover {
@@ -821,13 +841,27 @@ body {
   font-weight: 600;
   text-align: center;
   line-height: 1.2;
-  transition: transform 0.3s ease, box-shadow 0.3s ease;
+  transition: transform 0.3s ease, box-shadow 0.3s ease, opacity 0.3s ease;
   z-index: 50;
 }
 
 .home-button:hover {
   box-shadow: 0 0 10px var(--accent-blue);
   transform: scale(1.02);
+}
+
+.home-button.hidden {
+  transform: translateX(-120%);
+  opacity: 0;
+}
+
+@media (max-width: 640px) {
+  .home-button {
+    position: static;
+    width: 60px;
+    height: 60px;
+    margin-bottom: 8px;
+  }
 }
 
 /* Landing Page */

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1008,3 +1008,57 @@ body {
   border-radius: 8px;
   visibility: hidden;
 }
+
+/* Spoiler overlay */
+.spoiler-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: var(--blur-bg);
+  border: 1px solid var(--glass-border);
+  backdrop-filter: blur(20px);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  z-index: 100;
+}
+
+.spoiler-warning {
+  color: var(--accent-red);
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin-bottom: 16px;
+}
+
+.spoiler-question {
+  margin-bottom: 24px;
+}
+
+.spoiler-actions {
+  display: flex;
+  gap: 16px;
+}
+
+.spoiler-yes,
+.spoiler-no {
+  padding: 8px 20px;
+  border: none;
+  border-radius: 8px;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.spoiler-yes {
+  background: var(--accent-red);
+  color: var(--text-primary);
+}
+
+.spoiler-no {
+  background: var(--surface-tertiary);
+  color: var(--text-secondary);
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -524,6 +524,11 @@ body {
   margin: 0;
 }
 
+.footer-nav-list li {
+  /* Provide vertical space so hovered links don't overlap */
+  padding: 4px 0;
+}
+
 .footer-nav-list a {
   color: var(--text-secondary);
   text-decoration: none;
@@ -537,6 +542,7 @@ body {
   transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
   position: relative;
   overflow: hidden;
+  display: block;
 }
 
 .footer-nav-list a::before {
@@ -867,7 +873,8 @@ body {
 
 /* Landing Page */
 .landing-main {
-  min-height: 100vh;
+  /* Reduce main height so the footer is visible on standard PC displays */
+  min-height: auto;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -889,7 +896,6 @@ body {
   grid-template-columns: repeat(2, 1fr);
   gap: 24px;
   width: 100%;
-  height: calc(100vh - 140px);
 }
 
 .menu-card {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -20,8 +20,8 @@ export default function RootLayout({
   return (
     <html lang="ko">
       <body>
-        <HomeButton />
         <div className="container">
+          <HomeButton />
           <NavBar />
           {children}
           <Footer />

--- a/src/app/setlist/page.tsx
+++ b/src/app/setlist/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Inter } from 'next/font/google';
 
 const inter = Inter({ subsets: ['latin'], weight: ['600', '700', '800'] });
@@ -60,6 +60,22 @@ const group = (arr: Show[]) => {
 
 export default function Page() {
   const venues = useMemo(() => raw, []);
+  const [showWarning, setShowWarning] = useState(true);
+
+  useEffect(() => {
+    if (localStorage.getItem('setlistSpoilerConfirmed') === 'true') {
+      setShowWarning(false);
+    }
+  }, []);
+
+  const handleYes = () => {
+    localStorage.setItem('setlistSpoilerConfirmed', 'true');
+    setShowWarning(false);
+  };
+
+  const handleNo = () => {
+    window.location.href = '/';
+  };
 
   return (
     <main className={inter.className}>
@@ -107,6 +123,20 @@ export default function Page() {
           ))}
         </div>
       </section>
+      {showWarning && (
+        <div className="spoiler-overlay">
+          <p className="spoiler-warning">⚠️ 스포일러 주의</p>
+          <p className="spoiler-question">내용을 정말 확인하시겠습니까?</p>
+          <div className="spoiler-actions">
+            <button className="spoiler-yes" onClick={handleYes}>
+              예
+            </button>
+            <button className="spoiler-no" onClick={handleNo}>
+              아니오
+            </button>
+          </div>
+        </div>
+      )}
     </main>
   );
 }

--- a/src/app/setlist/page.tsx
+++ b/src/app/setlist/page.tsx
@@ -6,7 +6,7 @@ import { Inter } from 'next/font/google';
 
 const inter = Inter({ subsets: ['latin'], weight: ['600', '700', '800'] });
 
-type Show = { date: string; day: string; block: string; id: string | null };
+type Show = { date: string; day: string; block: string; id: string | null; hidden?: boolean };
 
 type Venue = { venue: string; shows: Show[] };
 
@@ -14,6 +14,7 @@ const raw: Venue[] = [
   {
     venue: '센다이',
     shows: [
+      { date: '08/01', day: '금', block: '낮', id: null, hidden: true },
       { date: '08/01', day: '금', block: '밤', id: '1' },
       { date: '08/02', day: '토', block: '낮', id: null },
       { date: '08/02', day: '토', block: '밤', id: null },
@@ -46,10 +47,13 @@ const raw: Venue[] = [
 ];
 
 const group = (arr: Show[]) => {
-  const map = new Map<string, { day: string; blocks: { block: string; id: string | null }[] }>();
+  const map = new Map<string, {
+    day: string;
+    blocks: { block: string; id: string | null; hidden?: boolean }[];
+  }>();
   arr.forEach((s) => {
     if (!map.has(s.date)) map.set(s.date, { day: s.day, blocks: [] });
-    map.get(s.date)!.blocks.push({ block: s.block, id: s.id });
+    map.get(s.date)!.blocks.push({ block: s.block, id: s.id, hidden: s.hidden });
   });
   return [...map].map(([date, { day, blocks }]) => ({ date, day, blocks }));
 };
@@ -76,12 +80,15 @@ export default function Page() {
                   <div key={date} className="date-row">
                     <span className="header-date">{`${date} (${day})`}</span>
                     <div className="block-buttons">
-                      {['낮', '밤'].map((t) => {
-                        const blk = blocks.find((b) => b.block === t);
-                        return blk?.id ? (
+                      {blocks.map(({ block: t, id, hidden }) =>
+                        hidden ? (
+                          <span key={t} className="block-placeholder">
+                            {t}
+                          </span>
+                        ) : id ? (
                           <Link
                             key={t}
-                            href={`/concerts/${blk.id}`}
+                            href={`/concerts/${id}`}
                             className="glass-effect block-link"
                           >
                             {t}
@@ -90,8 +97,8 @@ export default function Page() {
                           <span key={t} className="glass-effect block-disabled">
                             {t}
                           </span>
-                        );
-                      })}
+                        )
+                      )}
                     </div>
                   </div>
                 ))}

--- a/src/components/HomeButton.tsx
+++ b/src/components/HomeButton.tsx
@@ -2,13 +2,36 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
+import { useEffect, useState } from 'react';
 
 export default function HomeButton() {
   const pathname = usePathname();
+  const [isMobile, setIsMobile] = useState(false);
+  const [hidden, setHidden] = useState(false);
+
+  useEffect(() => {
+    const handleResize = () => {
+      setIsMobile(window.innerWidth < 640);
+    };
+    handleResize();
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  useEffect(() => {
+    if (isMobile) return;
+    const handleScroll = () => {
+      setHidden(window.scrollY > 200);
+    };
+    handleScroll();
+    window.addEventListener('scroll', handleScroll);
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, [isMobile]);
+
   if (pathname === '/') return null;
 
   return (
-    <Link href="/" className="home-button">
+    <Link href="/" className={`home-button${hidden ? ' hidden' : ''}`}>
       <span>2 0 2 5</span>
       <span>마지미라</span>
       <span>정보 모음</span>


### PR DESCRIPTION

https://github.com/user-attachments/assets/124af110-2e69-49d1-b0f4-6044b3fd6466


https://github.com/user-attachments/assets/9ef4fd1c-cf2d-431c-851c-e7a65ab17e99

<img width="698" height="266" alt="image" src="https://github.com/user-attachments/assets/2f0b6fc5-6f30-4fdd-8f26-dbaf5cef0381" />
<img width="473" height="515" alt="스크린샷 2025-08-03 013340" src="https://github.com/user-attachments/assets/0f716e28-5892-4310-a220-eba2c256c87c" />
<img width="1792" height="934" alt="스크린샷 2025-08-03 013307" src="https://github.com/user-attachments/assets/aaf6a176-6925-44ab-bbfa-949536072dbe" />

---

1. home-button이 화면을 가리는 이슈.
 - width가 좁아서 home button이 navigation bar를 가릴 정도면 Home button이 화면을 따라 위치하는게 아니라 navigation bar 위쪽 칸에 좀 더 작은 크기로 박혀있게 하였습니다. 이 경우에 작은 크기로 조정해서 글씨가 넘치는 경우가 생겨서 font 크기 조정해서 넘치지 않도록 하였습니다. 그리고 화면을 따라 내려가다가도 정보 영역의 object를 가릴 정도면 왼쪽 화면 밖으로 숨어 들어가도록 하였습니다. 다시 스크롤이 이동해서 object를 가리지 않는 영역이 오면 화면 안으로 튀어나오도록 하였습니다. 
2. footer의 navgation list가 width가 좁아서 세로로 배치될 경우 세로로 겹치는 이슈
 - 세로로 배치될때 겹치지 않도록 하였습니다.
3. title과  특히 상단 navigation bar가 width가 좁아서 줄바꿈이 되는 이슈
 - 줄바꿈이 될정도면 한줄에 표시될 정도로 font size를 줄였습니다.
4. setlist page에서 '센다이 - 0801 (금) - 낮' block은 존재하지 않으므로 숨겼습니다.
5. setlist page에서 glass-effect block-disabled 인 '낮', '밤'들은 전부 배경 색깔을 더 어둡게 처리하였습니다.
6. call-guide, exhibition-info, concert-guide page의 내용에 추가 예정입니다. 라는 내용을 넣었습니다.
7. landing page에서 pc 100% 확대 환경에서 footer까지 보이게 UI 크기 조정하였습니다.
8. setlist에 처음 접근할때 경고표시와 스포일러 글자는 빨간색으로 하여 예 아니오 버튼 확인하는 스포일러 창 띄웠습니다. 한번 예 누르면 local storage 이용하여 다시 묻지 않도록 하였습니다.

close #9 
close #10 