### PR TITLE
hotfix/add spoiler on footer page

### DIFF
--- a/src/app/concerts/[concertId]/page.tsx
+++ b/src/app/concerts/[concertId]/page.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Header from '@/components/Header';
 import SongList from '@/components/SongList';
+import SpoilerGate from '@/components/SpoilerGate';
 
 type Song = {
   title: string;
@@ -47,12 +48,14 @@ const ConcertPage = async ( props: { params: ConcertPageProps }) => {
   }
 
   return (
-    <main>
-      <Header title={concert.title} artist={concert.artist} date={concert.date} />
-      <section className="container">
-        <SongList songs={concert.songs} />
-      </section>
-    </main>
+    <SpoilerGate>
+      <main>
+        <Header title={concert.title} artist={concert.artist} date={concert.date} />
+        <section className="container">
+          <SongList songs={concert.songs} />
+        </section>
+      </main>
+    </SpoilerGate>
   );
 };
 

--- a/src/components/SpoilerGate.tsx
+++ b/src/components/SpoilerGate.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+
+interface Props {
+  children: React.ReactNode;
+}
+
+const SpoilerGate: React.FC<Props> = ({ children }) => {
+  const [showWarning, setShowWarning] = useState(true);
+
+  useEffect(() => {
+    if (localStorage.getItem('setlistSpoilerConfirmed') === 'true') {
+      setShowWarning(false);
+    }
+  }, []);
+
+  const handleYes = () => {
+    localStorage.setItem('setlistSpoilerConfirmed', 'true');
+    setShowWarning(false);
+  };
+
+  const handleNo = () => {
+    window.location.href = '/';
+  };
+
+  return (
+    <>
+      {children}
+      {showWarning && (
+        <div className="spoiler-overlay">
+          <p className="spoiler-warning">⚠️ 스포일러 주의</p>
+          <p className="spoiler-question">내용을 정말 확인하시겠습니까?</p>
+          <div className="spoiler-actions">
+            <button className="spoiler-yes" onClick={handleYes}>
+              예
+            </button>
+            <button className="spoiler-no" onClick={handleNo}>
+              아니오
+            </button>
+          </div>
+        </div>
+      )}
+    </>
+  );
+};
+
+export default SpoilerGate;


### PR DESCRIPTION

https://github.com/user-attachments/assets/92e914e0-b06c-4541-86f4-3f08f756b3f7

재사용 가능한 스포일러 경고 컴포넌트 만들었습니다.

이전 페이지도 이걸로 바꾸는게 더 깔끔할거같긴 한데 어차피 당장은 쓰이는곳이 두곳이니까 일단 급하게 수정했습니다.

근데 이정도 블러처리인데 앨범커버 흐릿한 색상 보고 맞출수도 있으려나요

close #10 