### PR TITLE
Add loading transition

### DIFF
--- a/src/app/concerts/[concertId]/page.tsx
+++ b/src/app/concerts/[concertId]/page.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Suspense } from 'react';
 import Header from '@/components/Header';
 import SongList from '@/components/SongList';
 
@@ -26,17 +26,22 @@ async function getConcerts(): Promise<ConcertsData> {
   if (!res.ok) {
     throw new Error('Failed to fetch concert data');
   }
-  return res.json();
+  return await res.json();
 }
 
 type ConcertPageProps = Promise<{
   concertId: string;
 }>;
 
-const ConcertPage = async ( props: { params: ConcertPageProps }) => {
+async function Songs({ concertId }: { concertId: string }) {
   const concerts = await getConcerts();
-  const concertId = (await props.params).concertId as keyof typeof concerts;
-  const concert = concerts[concertId];
+  const concert = concerts[concertId as keyof typeof concerts];
+  return <SongList songs={concert.songs} />;
+}
+
+const ConcertPage = async ( props: { params: ConcertPageProps}) => {
+  const concerts = await getConcerts();
+  const concert = concerts[(await props.params).concertId];
 
   if (!concert) {
     return (
@@ -50,7 +55,13 @@ const ConcertPage = async ( props: { params: ConcertPageProps }) => {
     <main>
       <Header title={concert.title} artist={concert.artist} date={concert.date} />
       <section className="container">
-        <SongList songs={concert.songs} />
+        <Suspense fallback={
+          <div className="loading-spinner-container">
+            <div className="loading-spinner"></div>
+          </div>
+        }>
+          <Songs concertId={(await props.params).concertId} />
+        </Suspense>
       </section>
     </main>
   );

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1062,3 +1062,27 @@ body {
   background: var(--surface-tertiary);
   color: var(--text-secondary);
 }
+
+/* Loading Spinner */
+.loading-spinner-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: calc(100vh - 400px);
+  min-height: 200px;
+}
+
+.loading-spinner {
+  width: 6rem;
+  height: 6rem;
+  border: 4px solid var(--surface-tertiary);
+  border-top-color: var(--accent-blue);
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -988,6 +988,8 @@ body {
   border-radius: 8px;
   font-size: 0.875rem;
   font-weight: 600;
+  color: var(--text-secondary);
+  text-decoration: none;
   transition: background 0.3s ease;
 }
 

--- a/src/app/setlist/page.tsx
+++ b/src/app/setlist/page.tsx
@@ -16,8 +16,8 @@ const raw: Venue[] = [
     shows: [
       { date: '08/01', day: '금', block: '낮', id: null, hidden: true },
       { date: '08/01', day: '금', block: '밤', id: '1' },
-      { date: '08/02', day: '토', block: '낮', id: null },
-      { date: '08/02', day: '토', block: '밤', id: null },
+      { date: '08/02', day: '토', block: '낮', id: '2' },
+      { date: '08/02', day: '토', block: '밤', id: '1' },
       { date: '08/03', day: '일', block: '낮', id: null },
       { date: '08/03', day: '일', block: '밤', id: null },
     ],

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -27,17 +27,17 @@ async function getConcerts(): Promise<Concerts> {
 }
 
 const Footer = async () => {
-  const concerts = await getConcerts();
+  // const concerts = await getConcerts();
 
   return (
     <footer className="footer">
       <nav>
         <ul className="footer-nav-list">
-          {Object.keys(concerts).map((concertId) => (
+          {/* {Object.keys(concerts).map((concertId) => (
             <li key={concertId}>
               <Link href={`/concerts/${concertId}`}>{concerts[concertId].title}</Link>
             </li>
-          ))}
+          ))} */}
         </ul>
       </nav>
     </footer>


### PR DESCRIPTION
<img width="868" height="794" alt="image" src="https://github.com/user-attachments/assets/428b52b4-0a0d-4cc5-aabb-45597b69a039" />

- #6 세트리스트 API fetch할 때 발생하는 지연시간 중 로딩 트랜지션 추가
- Footer에서 API 리퀘하면 전체적으로 페이지 로딩이 느려지는거 개에바라 삭제