### PR TITLE
Fix navbar toggle UI

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -839,9 +839,10 @@ body {
   .nav-toggle {
     display: flex;
     width: 100%;
+    height: 60px;
     align-items: center;
     justify-content: flex-end;
-    padding: 16px;
+    padding: 0 16px;
   }
 
   .nav-links {
@@ -850,7 +851,7 @@ body {
     width: 100%;
     background: var(--surface-secondary);
     border-top: 1px solid var(--border);
-    align-items: center;
+    align-items: stretch;
     max-height: 0;
     padding: 0 16px;
     overflow: hidden;
@@ -870,6 +871,13 @@ body {
     opacity: 1;
     visibility: visible;
     transform: translateY(0);
+  }
+
+  .nav-link {
+    display: block;
+    width: 100%;
+    padding: 8px 0;
+    text-align: center;
   }
 }
 
@@ -897,6 +905,7 @@ body {
     flex-direction: row;
     justify-content: space-between;
     align-items: center;
+    padding-top: 16px;
   }
 
   .top-bar .nav-bar {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -795,7 +795,6 @@ body {
 }
 
 /* Navigation Bar */
-
 .nav-bar {
   position: relative;
   width: 100%;
@@ -885,6 +884,29 @@ body {
   color: var(--accent-blue);
 }
 
+/* Top Bar */
+.top-bar {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+}
+
+@media (max-width: 640px) {
+  .top-bar {
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  .top-bar .nav-bar {
+    flex: 1;
+    width: auto;
+    padding: 0;
+    justify-content: flex-end;
+  }
+}
+
 /* Home Button */
 .home-button {
   position: fixed;
@@ -921,10 +943,8 @@ body {
 
 @media (max-width: 640px) {
   .home-button {
-    position: static;
     width: 60px;
     height: 60px;
-    margin-bottom: 8px;
     font-size: 0.75rem;
   }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -21,8 +21,10 @@ export default function RootLayout({
     <html lang="ko">
       <body>
         <div className="container">
-          <HomeButton />
-          <NavBar />
+          <div className="top-bar">
+            <HomeButton />
+            <NavBar />
+          </div>
           {children}
           <Footer />
         </div>

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 const links = [
   { href: '/setlist', label: '세트리스트' },
@@ -14,6 +14,9 @@ const links = [
 export default function NavBar() {
   const pathname = usePathname();
   const [isOpen, setIsOpen] = useState(false);
+  useEffect(() => {
+    setIsOpen(false);
+  }, [pathname]);
   if (pathname === '/') return null;
 
   return (


### PR DESCRIPTION

https://github.com/user-attachments/assets/b15503dc-0c91-4133-9321-65fc1a231bd1

---

1. 모바일 기기에서 toggle 되는 상황에서 home button하고 toggle 버튼이 같은 열에 있게 하였습니다.
2. toggle 하면 나오는 리스트창에서 글자만 클릭가능했는데 글자가 있는 그 row 전체가 클릭가능하게 하였습니다.
3. toggle 클릭 영역의 하단이 home button의 하단과 일치하도록 하였습니다. list가 home button과 겹치지 않고 아래로 펼쳐지도록 하기 위해서입니다.
4. toggle이 열려있는 상태에서 home button을 클릭해서 landing page로 갔다가 다시 sub page로 가면 toggle이 여전히 열려있는 이슈가 있었습니다. 한번 다른 페이지로 갔다오면 toggle은 닫혀있도록 수정했습니다.
