### PR TITLE
add floating playlist popup button and change concert date display

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -366,6 +366,15 @@ body {
   box-shadow: 0 16px 48px rgba(48, 209, 88, 0.2);
 }
 
+.song-item.final-playlist {
+  margin-top: 24px;
+}
+
+.song-item.final-playlist .song-title {
+  white-space: normal;
+  word-break: keep-all;
+}
+
 .song-info {
   display: flex;
   align-items: center;
@@ -1174,4 +1183,80 @@ body {
   to {
     transform: rotate(360deg);
   }
+}
+
+/* Playlist popup */
+.playlist-button {
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-primary);
+  cursor: pointer;
+  z-index: 90;
+}
+
+.playlist-panel {
+  position: fixed;
+  bottom: 24px;
+  right: 92px;
+  width: min(480px, calc(100vw - 120px));
+  max-height: 70vh;
+  overflow-y: auto;
+  padding: 16px;
+  border-radius: 20px;
+  box-shadow: 0 8px 32px var(--shadow);
+  z-index: 80;
+  transform-origin: bottom right;
+}
+
+.playlist-panel.open {
+  animation: popup-open 0.3s forwards;
+}
+
+.playlist-panel.close {
+  animation: popup-close 0.3s forwards;
+}
+
+@keyframes popup-open {
+  from {
+    opacity: 0;
+    transform: translateX(20px) scale(0.9);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0) scale(1);
+  }
+}
+
+@keyframes popup-close {
+  from {
+    opacity: 1;
+    transform: translateX(0) scale(1);
+  }
+  to {
+    opacity: 0;
+    transform: translateX(20px) scale(0.9);
+  }
+}
+
+.playlist-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.playlist-title {
+  font-weight: 600;
+  word-break: keep-all;
+}
+
+.playlist-links {
+  margin-left: auto;
 }

--- a/src/app/setlist/page.tsx
+++ b/src/app/setlist/page.tsx
@@ -104,7 +104,9 @@ export default function Page() {
                         ) : id ? (
                           <Link
                             key={t}
-                            href={`/concerts/${id}`}
+                            href={`/concerts/${id}?date=${encodeURIComponent(
+                              date
+                            )}&block=${encodeURIComponent(t)}`}
                             className="glass-effect block-link"
                           >
                             {t}

--- a/src/components/PlaylistPopup.tsx
+++ b/src/components/PlaylistPopup.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import Image from 'next/image';
+
+interface PlaylistPopupProps {
+  spotifyUrl?: string;
+  youtubeUrl?: string;
+  jacketUrl?: string;
+}
+
+const PlaylistPopup: React.FC<PlaylistPopupProps> = ({
+  spotifyUrl,
+  youtubeUrl,
+  jacketUrl,
+}) => {
+  const [open, setOpen] = useState(false);
+  const [visible, setVisible] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (open) setVisible(true);
+  }, [open]);
+
+  useEffect(() => {
+    const handlePointerDown = (e: PointerEvent) => {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(e.target as Node)
+      ) {
+        setOpen(false);
+      }
+    };
+    if (open) document.addEventListener('pointerdown', handlePointerDown);
+    return () => document.removeEventListener('pointerdown', handlePointerDown);
+  }, [open]);
+
+  return (
+    <div className="playlist-container" ref={containerRef}>
+      <button
+        className="playlist-button glass-effect"
+        onClick={() => setOpen((v) => !v)}
+        aria-label={open ? 'Close playlist' : 'Open playlist'}
+      >
+        {open ? '✕' : (
+          <Image src="/list.svg" alt="playlist" width={24} height={24} />
+        )}
+      </button>
+      {visible && (
+        <div
+          className={`playlist-panel glass-effect ${open ? 'open' : 'close'}`}
+          onAnimationEnd={() => {
+            if (!open) setVisible(false);
+          }}
+        >
+          <div className="playlist-header">
+            {jacketUrl && (
+              <Image
+                src={jacketUrl}
+                alt="playlist jacket"
+                width={48}
+                height={48}
+              />
+            )}
+            <span className="playlist-title">
+              최종 플레이<wbr />리스트
+            </span>
+            <div className="song-links playlist-links">
+              {spotifyUrl && (
+                <a href={spotifyUrl} target="_blank" rel="noopener noreferrer">
+                  <Image src="/spotify.svg" alt="Spotify" width={24} height={24} />
+                </a>
+              )}
+              {youtubeUrl && (
+                <a href={youtubeUrl} target="_blank" rel="noopener noreferrer">
+                  <Image src="/youtube.svg" alt="YouTube" width={24} height={24} />
+                </a>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default PlaylistPopup;

--- a/src/components/SongList.tsx
+++ b/src/components/SongList.tsx
@@ -20,7 +20,11 @@ const SongList: React.FC<SongListProps> = ({ songs }) => {
   return (
     <div className="song-list">
       {songs.map((song, index) => {
-        const itemClass = song.higawari
+        const isFinalPlaylist =
+          song.title === '최종 플레이리스트' || song.artist === '';
+        const itemClass = isFinalPlaylist
+          ? 'song-item final-playlist'
+          : song.higawari
           ? 'song-item higawari'
           : song.locationgawari
           ? 'song-item locationgawari'
@@ -31,7 +35,9 @@ const SongList: React.FC<SongListProps> = ({ songs }) => {
         return (
           <div className={itemClass} key={index}>
             <div className="song-info">
-              <span className="song-index">{index + 1}</span>
+              {!isFinalPlaylist && (
+                <span className="song-index">{index + 1}</span>
+              )}
               <div className="song-details">
                 <Image
                   src={song.jacketUrl}
@@ -41,36 +47,48 @@ const SongList: React.FC<SongListProps> = ({ songs }) => {
                   className="song-jacket"
                 />
                 <div className="song-text-info">
-                  <p className="song-title">{finalTitle}</p>
-                  <p className="song-artist">{song.artist}</p>
+                  <p className="song-title">
+                    {isFinalPlaylist ? (
+                      <>
+                        최종 플레이<wbr />리스트
+                      </>
+                    ) : (
+                      finalTitle
+                    )}
+                  </p>
+                  {song.artist && <p className="song-artist">{song.artist}</p>}
                 </div>
               </div>
             </div>
             <div className="song-links">
-              <a
-                href={song.spotifyUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                <Image
-                  src="/spotify.svg"
-                  alt="Spotify"
-                  width={24}
-                  height={24}
-                />
-              </a>
-              <a
-                href={song.youtubeUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                <Image
-                  src="/youtube.svg"
-                  alt="YouTube"
-                  width={24}
-                  height={24}
-                />
-              </a>
+              {song.spotifyUrl && (
+                <a
+                  href={song.spotifyUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <Image
+                    src="/spotify.svg"
+                    alt="Spotify"
+                    width={24}
+                    height={24}
+                  />
+                </a>
+              )}
+              {song.youtubeUrl && (
+                <a
+                  href={song.youtubeUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <Image
+                    src="/youtube.svg"
+                    alt="YouTube"
+                    width={24}
+                    height={24}
+                  />
+                </a>
+              )}
             </div>
           </div>
         );


### PR DESCRIPTION
https://github.com/user-attachments/assets/ce762871-1190-4cb9-9b0c-d2fc3ed8ba96

<img width="1182" height="594" alt="스크린샷 2025-08-03 150444" src="https://github.com/user-attachments/assets/989418de-b372-4092-9f4f-0cd6e79381da" />
<img width="549" height="314" alt="스크린샷 2025-08-03 150449" src="https://github.com/user-attachments/assets/ade6362e-f21a-447e-b119-64100f3cc8ff" />

1. 세트리스트 페이지 우하단에 작고 반투명한 리스트 버튼을 띄워서, 클릭 시 최종 플레이리스트 목록이 왼쪽 팝업으로 펼쳐지게 하였습니다.
버튼은 항상 화면 우하단에 고정되어 떠 있고, 팝업 닫는 방식은 X 버튼(팝업으로 펼쳐졌을때 기존 버튼위치에 X로 바뀐 버튼이 됨)이나 외부 클릭 하는 식으로 하였습니다.
2. /concerts/id 페이지에서 date={concert.date}에 들어갈 내용이, 만약에 이전 페이지가 /setlist 페이지고 거기서 낮 밤 box 클릭해서 접근했다면 해당 날짜 낮/밤 공연 내용으로 date를 대체하였습니다. query string을 사용하여 정보를 넘겨주었습니다.
3. 기존대로 최종 플레이리스트가 최하단에 표시되는것도 유지하였습니다. 
위쪽 플레이리스트 영역과 약간 거리를 두고 표시되게 바꾸고최종 플레이리스트는 번호를 없앴습니다.

close #17 
