### PR TITLE
fix-spoiler-page-when-scrolling

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1110,10 +1110,7 @@ body {
 /* Spoiler overlay */
 .spoiler-overlay {
   position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
+  inset: 0;
   background: var(--blur-bg);
   border: 1px solid var(--glass-border);
   backdrop-filter: blur(20px);

--- a/src/app/setlist/page.tsx
+++ b/src/app/setlist/page.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import Link from 'next/link';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import { Inter } from 'next/font/google';
+import SpoilerGate from '@/components/SpoilerGate';
 
 const inter = Inter({ subsets: ['latin'], weight: ['600', '700', '800'] });
 
@@ -60,26 +61,11 @@ const group = (arr: Show[]) => {
 
 export default function Page() {
   const venues = useMemo(() => raw, []);
-  const [showWarning, setShowWarning] = useState(true);
-
-  useEffect(() => {
-    if (localStorage.getItem('setlistSpoilerConfirmed') === 'true') {
-      setShowWarning(false);
-    }
-  }, []);
-
-  const handleYes = () => {
-    localStorage.setItem('setlistSpoilerConfirmed', 'true');
-    setShowWarning(false);
-  };
-
-  const handleNo = () => {
-    window.location.href = '/';
-  };
 
   return (
-    <main className={inter.className}>
-      <header className="header">
+    <SpoilerGate>
+      <main className={inter.className}>
+        <header className="header">
         <div className="container header-content">
           <h1 className="header-title">세트리스트</h1>
           <p className="header-subtitle">공연 회차를 선택하세요</p>
@@ -125,20 +111,7 @@ export default function Page() {
           ))}
         </div>
       </section>
-      {showWarning && (
-        <div className="spoiler-overlay">
-          <p className="spoiler-warning">⚠️ 스포일러 주의</p>
-          <p className="spoiler-question">내용을 정말 확인하시겠습니까?</p>
-          <div className="spoiler-actions">
-            <button className="spoiler-yes" onClick={handleYes}>
-              예
-            </button>
-            <button className="spoiler-no" onClick={handleNo}>
-              아니오
-            </button>
-          </div>
-        </div>
-      )}
-    </main>
+      </main>
+    </SpoilerGate>
   );
 }

--- a/src/components/SpoilerGate.tsx
+++ b/src/components/SpoilerGate.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useLayoutEffect, useState } from 'react';
 
 interface Props {
   children: React.ReactNode;
@@ -9,11 +9,20 @@ interface Props {
 const SpoilerGate: React.FC<Props> = ({ children }) => {
   const [showWarning, setShowWarning] = useState(true);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (localStorage.getItem('setlistSpoilerConfirmed') === 'true') {
       setShowWarning(false);
     }
   }, []);
+
+  useEffect(() => {
+    if (!showWarning) return;
+    const originalStyle = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = originalStyle;
+    };
+  }, [showWarning]);
 
   const handleYes = () => {
     localStorage.setItem('setlistSpoilerConfirmed', 'true');


### PR DESCRIPTION
모바일 환경에서 스포일러 페이지가 떴을때 아래로 페이지 내릴때 상단바 숨겨지는 것 때문인지 간혹 아래영역이 가려지지 않고 드러나는 이슈가 있었습니다.

스포일러 페이지가 뜨면 페이지 뒤 오브젝트와의 스크롤과 같은 상호작용이 가능한 이슈가 있고 그걸 막았습니다.

상단바 숨겨지는걸로 스크롤되더라도 가려지지 않도록 처리하였습니다 -> 이건 실제 모바일환경에서 테스트해봐야 할 것 같습니다. f12 devtools로는 상단바가 없어서 테스트가 안되네요

이미 스포일러 확인버튼 누른 경우에도 로딩시 스포일러 페이지 아주 잠깐 점멸하듯이 떴다가 사라지는 이슈를 해결했습니다.

그리고 /setlist 페이지도 스포일러 페이지 component 사용하도록 하여 중복 코드 삭제하였습니다