### PR TITLE
update-title…page-content

### DIFF
--- a/src/app/call-guide/page.tsx
+++ b/src/app/call-guide/page.tsx
@@ -1,3 +1,7 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = { title: '콜 가이드' };
+
 export default function CallGuidePage() {
   return (
     <main className="container" style={{ textAlign: 'center', paddingTop: '4rem' }}>

--- a/src/app/concert-guide/page.tsx
+++ b/src/app/concert-guide/page.tsx
@@ -1,3 +1,7 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = { title: '공연 가이드' };
+
 export default function CallGuidePage() {
   return (
     <main className="container" style={{ textAlign: 'center', paddingTop: '4rem' }}>

--- a/src/app/concerts/[concertId]/page.tsx
+++ b/src/app/concerts/[concertId]/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from 'next';
 import React, { Suspense } from 'react';
 import Header from '@/components/Header';
 import SongList from '@/components/SongList';
@@ -35,6 +36,13 @@ type ConcertPageProps = {
   params: Promise<{ concertId: string }>;
   searchParams: Promise<{ date?: string; block?: string }>;
 };
+
+export async function generateMetadata({ params }: ConcertPageProps): Promise<Metadata> {
+  const { concertId } = await params;
+  const concerts = await getConcerts();
+  const concert = concerts[concertId];
+  return { title: concert ? concert.title : '콘서트를 찾을 수 없습니다.' };
+}
 
 const ConcertPage = async ({ params, searchParams }: ConcertPageProps) => {
   const { concertId } = await params;

--- a/src/app/exhibition-info/page.tsx
+++ b/src/app/exhibition-info/page.tsx
@@ -1,3 +1,7 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = { title: '기획전 정보' };
+
 export default function ExhibitionInfoPage() {
   return (
     <main className="container" style={{ textAlign: 'center', paddingTop: '4rem' }}>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,7 +5,10 @@ import NavBar from "@/components/NavBar";
 import HomeButton from "@/components/HomeButton";
 
 export const metadata: Metadata = {
-  title: "세트리스트",
+  title: {
+    default: "MM-Info",
+    template: "%s | MM-Info",
+  },
   description: "콘서트 세트리스트 공유 플랫폼",
   icons: {
     icon: "/favicon.png",

--- a/src/app/setlist/page.tsx
+++ b/src/app/setlist/page.tsx
@@ -1,7 +1,5 @@
-'use client';
-
+import type { Metadata } from 'next';
 import Link from 'next/link';
-import { useMemo } from 'react';
 import { Inter } from 'next/font/google';
 import SpoilerGate from '@/components/SpoilerGate';
 
@@ -47,6 +45,8 @@ const raw: Venue[] = [
   },
 ];
 
+export const metadata: Metadata = { title: '세트리스트' };
+
 const group = (arr: Show[]) => {
   const map = new Map<string, {
     day: string;
@@ -60,7 +60,7 @@ const group = (arr: Show[]) => {
 };
 
 export default function Page() {
-  const venues = useMemo(() => raw, []);
+  const venues = raw;
 
   return (
     <SpoilerGate>


### PR DESCRIPTION
https://github.com/user-attachments/assets/a8ff5c94-d3be-4d1e-b253-ad6a3f4ede38


지금 title이 '세트리스트'로 통일되어 있는데

각 페이지 내용에 맞게 설정하기 설정하였습니다

Landing page -> MM-Info
/setlist -> 세트리스트 | MM-Info

이런식으로 하였습니다.

close #19