### PR TITLE
Add og:image for link preview

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -13,6 +13,13 @@ export const metadata: Metadata = {
   icons: {
     icon: "/favicon.png",
   },
+  openGraph: {
+    images: [
+      {
+        url: "/favicon.png",
+      },
+    ],
+  },
 };
 
 export default function RootLayout({


### PR DESCRIPTION
<img width="1068" height="282" alt="image" src="https://github.com/user-attachments/assets/5314a250-5e58-4814-a457-bd325844e10d" />

이렇게 미리보기 이미지 안보여서 og image 메타데이터 추가

일단 favicon.png 사용했는데 다른 좋은거 쓰면 좋을거같네요

간단한거라 선머지 하겠습니다