### PR TITLE
Feature/add order of call-guide list

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1328,11 +1328,35 @@ body {
   border-radius: 24px;
   backdrop-filter: blur(20px);
   transition: box-shadow 0.3s ease, transform 0.3s ease;
+  position: relative;
+  overflow: hidden;
 }
 
 .call-item:hover {
   box-shadow: 0 0 10px var(--accent-blue);
   transform: scale(1.02);
+}
+
+.call-item.higawari {
+  background: linear-gradient(135deg, rgba(0, 122, 255, 0.1) 0%, rgba(0, 122, 255, 0.05) 100%);
+  border-color: rgba(0, 122, 255, 0.3);
+}
+
+.call-item.higawari:hover {
+  background: linear-gradient(135deg, rgba(0, 122, 255, 0.15) 0%, rgba(0, 122, 255, 0.08) 100%);
+  border-color: rgba(0, 122, 255, 0.5);
+  box-shadow: 0 16px 48px rgba(0, 122, 255, 0.2);
+}
+
+.call-item.locationgawari {
+  background: linear-gradient(135deg, rgba(48, 209, 88, 0.1) 0%, rgba(48, 209, 88, 0.05) 100%);
+  border-color: rgba(48, 209, 88, 0.3);
+}
+
+.call-item.locationgawari:hover {
+  background: linear-gradient(135deg, rgba(48, 209, 88, 0.15) 0%, rgba(48, 209, 88, 0.08) 100%);
+  border-color: rgba(48, 209, 88, 0.5);
+  box-shadow: 0 16px 48px rgba(48, 209, 88, 0.2);
 }
 
 .call-info-link {


### PR DESCRIPTION
<img width="924" height="849" alt="image" src="https://github.com/user-attachments/assets/e9afd74b-276e-45ce-86fa-07f7cc4f205b" />

콜 가이드 리스트 페이지에 곡의 순서(order) 표시, 히가와리-지역가와리 표시, 파트 표시를 추가하였습니다.