### PR TITLE
Fix/call guide page bug and add features

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1556,11 +1556,31 @@ body {
   z-index: 1000;
 }
 
-.player-seek {
+
+.seek-container {
+  position: relative;
   width: 80vw;
+}
+
+.skip-button {
+  position: absolute;
+  left: 0;
+  bottom: calc(100% + 0.5rem);
+  padding: 0.5rem 1rem;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.3);
+  border: 1px solid var(--glass-border);
+  color: #000;
+  backdrop-filter: blur(8px);
+  font-size: 0.9rem;
+  z-index: 1001;
+}
+
+.player-seek {
+  width: 100%;
   -webkit-appearance: none;
   appearance: none;
-  background: rgba(255, 255, 255, 0.3);
+  background: rgba(255, 255, 255, 0.15);
   border: 1px solid var(--glass-border);
   height: 8px;
   border-radius: 8px;
@@ -1588,8 +1608,9 @@ body {
   transition: box-shadow 0.3s ease;
 }
 
+
 .player-seek:hover {
-  box-shadow: 0 0 8px rgba(255, 255, 255, 0.6);
+  box-shadow: 0 0 8px #39c5bb;
 }
 
 .player-seek:hover::-webkit-slider-thumb {


### PR DESCRIPTION
<img width="1111" height="170" alt="image" src="https://github.com/user-attachments/assets/388bd4a7-6db8-4c66-853b-3ddc82855485" />

* call-guide의 곡 재생 페이지에 간주 스킵 기능을 넣었습니다. 다음 가사까지 10초이상 간격이 있으면 1초후에 버튼이 뜨도록 하였습니다.
* 곡 지난시간 bar에서 지난시간 부분은 회색조로 해서 시인성을 높였고, bar에 미쿠색 glow effect를 넣어서 시인성을 높였습니다.
* 너무 빠르게 가사가 넘어가면 손도 안댔는데 focus 꺼지는 버그를 고쳤습니다
* 임의의 위치 가사를 눌렀을때, 그 가사 시점으로 로드되어야 합니다. 근데 youtube실제 영상 로드가 느리면 그 위치 시점이 아니라 로드되기 전 시점으로 고정되는 버그가 있었습니다. 이걸 해결하기 위해 영상이 로드될때까지 누른 위치를 기다리고 있다가 영상 로드된거 확인하면 lazy하게 그 위치로 가게 하였습니다.