### PR TITLE
Fix/mobile home button disappear bug

### DIFF
--- a/src/components/HomeButton.tsx
+++ b/src/components/HomeButton.tsx
@@ -2,14 +2,14 @@
 
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
+import { usePathname } from 'next/navigation';
 
 export default function HomeButton() {
-  const [show, setShow] = useState(false);
+  const pathname = usePathname();
   const [isMobile, setIsMobile] = useState(false);
   const [hidden, setHidden] = useState(false);
 
   useEffect(() => {
-    setShow(window.location.pathname !== '/');
     const handleResize = () => {
       setIsMobile(window.innerWidth < 640);
     };
@@ -19,19 +19,20 @@ export default function HomeButton() {
   }, []);
 
   useEffect(() => {
-    if (isMobile) return;
     const handleScroll = () => {
-      setHidden(window.scrollY > 200);
+      setHidden(window.scrollY > (isMobile ? 0 : 200));
     };
     handleScroll();
     window.addEventListener('scroll', handleScroll);
     return () => window.removeEventListener('scroll', handleScroll);
   }, [isMobile]);
 
-  if (!show) return null;
-
   return (
-    <Link href="/" className={`home-button${hidden ? ' hidden' : ''}`}>
+    <Link
+      href='/'
+      className={`home-button${hidden ? ' hidden' : ''}`}
+      style={{ display: pathname === '/' ? 'none' : undefined }}
+    >
       <span>2 0 2 5</span>
       <span>마지미라</span>
       <span>정보 모음</span>


### PR DESCRIPTION
<img width="680" height="438" alt="image" src="https://github.com/user-attachments/assets/df9c8c1f-e025-41e4-a06e-c23de8ffdcb5" />

모바일 환경에서 landing page가 아닌 페이지에서 새로고침 할 경우 home button이 종종 사라지는 버그를 고쳤습니다.