### PR TITLE
Improve mobile performance and add lazy image loading

### DIFF
--- a/src/app/concert-guide/important/page.tsx
+++ b/src/app/concert-guide/important/page.tsx
@@ -86,6 +86,7 @@ export default function ImportantNoticesPage() {
                   src="images/images/mail_linkst.svg"
                   className="inquiry_mail"
                   alt=""
+                  loading="lazy"
                 />
                 <a
                   href="mailto:event@linkst.jp"

--- a/src/app/exhibition-info/tokyo/creators-market/components/BoothList.tsx
+++ b/src/app/exhibition-info/tokyo/creators-market/components/BoothList.tsx
@@ -7,7 +7,9 @@ import {
   useLayoutEffect,
   Fragment,
   CSSProperties,
+  useCallback,
 } from 'react';
+import useThrottle from '@/hooks/useThrottle';
 import Image from 'next/image';
 import { ROWS, rowClasses, BOOTHS } from '@/data/exhibition/tokyo/creators-market/booths';
 import {
@@ -34,25 +36,27 @@ const BoothList = forwardRef<BoothListHandle, BoothListProps>(
   const listRefs = useRef<Record<string, HTMLLIElement | null>>({});
   const rowRefs = useRef<Record<string, HTMLLIElement | null>>({});
 
-  useLayoutEffect(() => {
-    const updateDividers = () => {
-      const wrapper = document.querySelector('.cm-map-wrapper') as HTMLDivElement | null;
-      if (!wrapper) return;
-      const parentRect = wrapper.getBoundingClientRect();
-      const style = getComputedStyle(wrapper);
-      const rightGap = parseFloat(style.paddingRight) || 0;
-      const maxWidth = Math.min(parentRect.width, window.innerWidth);
-      Object.values(rowRefs.current).forEach(li => {
-        if (!li) return;
-        const width = maxWidth - rightGap;
-        li.style.setProperty('--divider-left', '0px');
-        li.style.setProperty('--divider-width', `${width}px`);
-      });
-    };
-    updateDividers();
-    window.addEventListener('resize', updateDividers);
-    return () => window.removeEventListener('resize', updateDividers);
+  const updateDividers = useCallback(() => {
+    const wrapper = document.querySelector('.cm-map-wrapper') as HTMLDivElement | null;
+    if (!wrapper) return;
+    const parentRect = wrapper.getBoundingClientRect();
+    const style = getComputedStyle(wrapper);
+    const rightGap = parseFloat(style.paddingRight) || 0;
+    const maxWidth = Math.min(parentRect.width, window.innerWidth);
+    Object.values(rowRefs.current).forEach(li => {
+      if (!li) return;
+      const width = maxWidth - rightGap;
+      li.style.setProperty('--divider-left', '0px');
+      li.style.setProperty('--divider-width', `${width}px`);
+    });
   }, []);
+  const throttledUpdateDividers = useThrottle(updateDividers, 100);
+
+  useLayoutEffect(() => {
+    throttledUpdateDividers();
+    window.addEventListener('resize', throttledUpdateDividers);
+    return () => window.removeEventListener('resize', throttledUpdateDividers);
+  }, [throttledUpdateDividers]);
 
   const scrollToBooth = (id: string) => {
     const el = listRefs.current[id];

--- a/src/app/exhibition-info/tokyo/creators-market/components/BoothMap.tsx
+++ b/src/app/exhibition-info/tokyo/creators-market/components/BoothMap.tsx
@@ -13,6 +13,7 @@ import {
   CSSProperties,
   type ReactNode,
 } from 'react';
+import useThrottle from '@/hooks/useThrottle';
 import Image from 'next/image';
 import type { Booth } from '@/types/booth';
 import { ROWS, COLS, rowClasses, BOOTHS } from '@/data/exhibition/tokyo/creators-market/booths';
@@ -265,19 +266,20 @@ const BoothMap = forwardRef<BoothMapHandle, BoothMapProps>(
       if (activeTooltip.current === el) activeTooltip.current = null;
     };
 
+    const handleScroll = useThrottle(() => {
+      const active = activeTooltip.current;
+      if (!active) return;
+      if (active.matches(':hover') || disableScrollHide.current) {
+        updateTooltipPosition(active);
+      } else {
+        hideTooltip(active);
+      }
+    }, 100);
+
     useEffect(() => {
-      const handleScroll = () => {
-        const active = activeTooltip.current;
-        if (!active) return;
-        if (active.matches(':hover') || disableScrollHide.current) {
-          updateTooltipPosition(active);
-        } else {
-          hideTooltip(active);
-        }
-      };
       window.addEventListener('scroll', handleScroll, { passive: true });
       return () => window.removeEventListener('scroll', handleScroll);
-    }, []);
+    }, [handleScroll]);
 
     useEffect(() => {
       const handlePointerDown = (e: PointerEvent) => {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import "./globals.css";
 import Footer from "@/components/Footer";
 import NavBar from "@/components/NavBar";
 import HomeButton from "@/components/HomeButton";
+import ViewportHeightSetter from "@/components/ViewportHeightSetter";
 
 export const metadata: Metadata = {
   title: {
@@ -30,6 +31,7 @@ export default function RootLayout({
   return (
     <html lang="ko">
       <body>
+        <ViewportHeightSetter />
         <div className="container">
           <div className="top-bar">
             <HomeButton />

--- a/src/components/HomeButton.tsx
+++ b/src/components/HomeButton.tsx
@@ -3,29 +3,32 @@
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
 import { usePathname } from 'next/navigation';
+import useThrottle from '@/hooks/useThrottle';
 
 export default function HomeButton() {
   const pathname = usePathname();
   const [isMobile, setIsMobile] = useState(false);
   const [hidden, setHidden] = useState(false);
 
+  const handleResize = useThrottle(() => {
+    setIsMobile(window.innerWidth < 640);
+  }, 200);
+
   useEffect(() => {
-    const handleResize = () => {
-      setIsMobile(window.innerWidth < 640);
-    };
     handleResize();
     window.addEventListener('resize', handleResize);
     return () => window.removeEventListener('resize', handleResize);
-  }, []);
+  }, [handleResize]);
+
+  const handleScroll = useThrottle(() => {
+    setHidden(window.scrollY > (isMobile ? 0 : 200));
+  }, 100);
 
   useEffect(() => {
-    const handleScroll = () => {
-      setHidden(window.scrollY > (isMobile ? 0 : 200));
-    };
     handleScroll();
-    window.addEventListener('scroll', handleScroll);
+    window.addEventListener('scroll', handleScroll, { passive: true });
     return () => window.removeEventListener('scroll', handleScroll);
-  }, [isMobile]);
+  }, [handleScroll]);
 
   return (
     <Link

--- a/src/components/ScrollTopButton.tsx
+++ b/src/components/ScrollTopButton.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import useThrottle from '@/hooks/useThrottle';
 import { scrollToPosition } from '@/lib/scroll';
 
 interface ScrollTopButtonProps {
@@ -10,11 +11,12 @@ interface ScrollTopButtonProps {
 export default function ScrollTopButton({ className = '' }: ScrollTopButtonProps) {
   const [visible, setVisible] = useState(false);
 
+  const onScroll = useThrottle(() => setVisible(window.scrollY > 200), 100);
+
   useEffect(() => {
-    const onScroll = () => setVisible(window.scrollY > 200);
-    window.addEventListener('scroll', onScroll);
+    window.addEventListener('scroll', onScroll, { passive: true });
     return () => window.removeEventListener('scroll', onScroll);
-  }, []);
+  }, [onScroll]);
 
   return (
     <button

--- a/src/components/ViewportHeightSetter.tsx
+++ b/src/components/ViewportHeightSetter.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { useEffect } from 'react';
+import useThrottle from '@/hooks/useThrottle';
+
+export default function ViewportHeightSetter() {
+  const setVh = useThrottle(() => {
+    const vh = window.innerHeight * 0.01;
+    document.documentElement.style.setProperty('--vh', `${vh}px`);
+  }, 100);
+
+  useEffect(() => {
+    setVh();
+    window.addEventListener('resize', setVh);
+    window.addEventListener('orientationchange', setVh);
+    return () => {
+      window.removeEventListener('resize', setVh);
+      window.removeEventListener('orientationchange', setVh);
+    };
+  }, [setVh]);
+  return null;
+}

--- a/src/hooks/useThrottle.ts
+++ b/src/hooks/useThrottle.ts
@@ -1,0 +1,23 @@
+'use client';
+
+import { useRef, useCallback } from 'react';
+
+export default function useThrottle<T extends (...args: unknown[]) => void>(
+  fn: T,
+  delay: number,
+) {
+  const lastCalled = useRef(0);
+  const savedFn = useRef(fn);
+  savedFn.current = fn;
+
+  return useCallback(
+    (...args: Parameters<T>) => {
+      const now = Date.now();
+      if (now - lastCalled.current >= delay) {
+        lastCalled.current = now;
+        savedFn.current(...args);
+      }
+    },
+    [delay],
+  );
+}

--- a/src/styles/landing.css
+++ b/src/styles/landing.css
@@ -1,6 +1,6 @@
 /* Landing Page Styles */
 .landing-hero {
-  min-height: 100vh;
+  min-height: calc(var(--vh, 1vh) * 100);
   display: flex;
   flex-direction: column;
   justify-content: center;

--- a/src/styles/overlays.css
+++ b/src/styles/overlays.css
@@ -54,7 +54,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  height: calc(100vh - 400px);
+  height: calc(var(--vh, 1vh) * 100 - 400px);
   min-height: 200px;
 }
 
@@ -94,7 +94,7 @@
   bottom: 24px;
   right: 92px;
   width: min(480px, calc(100vw - 120px));
-  max-height: 70vh;
+  max-height: calc(var(--vh, 1vh) * 70);
   overflow-y: auto;
   padding: 16px;
   border-radius: 20px;


### PR DESCRIPTION
* 리사이즈 및 스크롤 이벤트 실행 빈도를 줄이기 위해 재사용 가능한 throttle 훅을 생성하고, 여러 컴포넌트에 적용하여 모바일 기기에서의 반응성을 개선했습니다.
* 브라우저 뷰 변동에 대응하고 모바일 세로 모드에서 불필요한 reflow를 방지하기 위해, 클라이언트 사이드에서 뷰포트 높이를 CSS 변수로 설정하고 기존 vh 사용을 대체했습니다.
* 초기 페이지 로딩 시 렉 줄이기 위해 정적 이미지에 lazy loading을 적용했습니다.
