### PR TITLE
Feature/enhance mobile ux

### DIFF
--- a/src/app/call-guide/[slug]/LyricsDisplay.tsx
+++ b/src/app/call-guide/[slug]/LyricsDisplay.tsx
@@ -30,6 +30,7 @@ export default function LyricsDisplay({
         <div
           key={idx}
           className={`lyric-line${idx === activeLine ? ' focused' : ''}`}
+          tabIndex={-1}
           ref={(el) => {
             lineRefs.current[idx] = el!;
           }}

--- a/src/styles/call-guide.css
+++ b/src/styles/call-guide.css
@@ -781,6 +781,10 @@
   transition: background 0.3s ease;
 }
 
+.lyric-line:focus {
+  outline: none; 
+}
+
 .lyric-line.focused {
   background: rgba(255, 255, 255, 0.1);
   border-radius: 8px;


### PR DESCRIPTION

https://github.com/user-attachments/assets/a0edf2f8-55c8-4fe1-958e-b684721c2d36

곡 재생 상태를 sessionStorage에 저장해서 같은 Session에서 새로고침되거나 인터넷 끊겼다 다시 접속되거나 할때 원활하게 이어듣는 것에 대응해봤습니다

이게 써보니까 백그라운드에 있다가 돌아오면 현재 가사로 스크롤되긴 하는데 포커싱이 안되더라고요 그부분 되게 고쳤는데 실제로 될지는 테스트해본게 아니라서 모바일 환경에서 실사용해봐야 알것같네요

또 상단에 유튜브 같은것처럼 재생정보 바가 나오도록 했는데 잘 될지는 모르겠네요 이것도 써봐야 알것같습니다

아무튼 이번 pr에서는 백그라운드나 라우팅이 바뀌거나 연결이 불안정하거나 하는 극한상황에서도 원활하게 들을수 있도록 ux 개선해봤습니다